### PR TITLE
Updates broken link to TLC guide in French and English versions

### DIFF
--- a/notes-en.html
+++ b/notes-en.html
@@ -46,7 +46,7 @@
 
         * Scratch <a href="https://scratch.mit.edu/educators/#resources">Educator Resources</a> (especially the <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Getting Started Guide</a>)
         * Google CS First <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Training Materials</a>
-        * Teachers Learning Code <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a>
+        * Teachers Learning Code <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a>
         * Scratch ED: Using the Scratch <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Teacher Account</a>
 
         <br>
@@ -134,7 +134,7 @@
 
     * Scratch <a href="https://scratch.mit.edu/educators/#resources">Educator Resources</a> (especially the <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Getting Started Guide</a>)
     * Google CS First <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Training Materials</a>
-    * Teachers Learning Code <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a>
+    * Teachers Learning Code <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a>
     * Scratch ED: Using the Scratch <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Teacher Account</a>
     </script>
   </section>

--- a/notes-fr.html
+++ b/notes-fr.html
@@ -46,7 +46,7 @@
 
         * <a href="https://scratch.mit.edu/educators/#resources">Ressources pour les éducateurs</a> (sélectionnez l’option « français » en bas de la page et consultez le guide <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Pour bien démarrer</a>)
         * <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Notions et exercices</a> Google CS First (en anglais)
-        * <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a> Teachers Learning Code  (en anglais)
+        * <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a> Teachers Learning Code  (en anglais)
         * <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Guide pour les comptes pour enseignant</a> Scratch ED: Using the Scratch (en anglais)
 
         <br>
@@ -133,7 +133,7 @@
 
       * <a href="https://scratch.mit.edu/educators/#resources">Ressources pour les éducateurs</a> (sélectionnez l’option « français » en bas de la page et consultez le guide <a href="https://cdn.scratch.mit.edu/scratchr2/static/__0c1805349a6fe15c01c668d3f8acd971__/pdfs/help/Getting-Started-Guide-Scratch2.pdf">Pour bien démarrer</a>)
       * <a href="https://www.cs-first.com/training/introduction-computer-science-and-scratch">Notions et exercices</a> Google CS First (en anglais)
-      * <a href="http://teacherslearningcode.com/assets/TLC-gettingstartedguide.pdf">Guide</a> Teachers Learning Code  (en anglais)
+      * <a href="https://www.canadalearningcode.ca/wp-content/uploads/teacher-quick-start-guide.pdf">Guide</a> Teachers Learning Code  (en anglais)
       * <a href="http://scratched.gse.harvard.edu/resources/scratch-teacher-accounts">Guide pour les comptes pour enseignant</a> Scratch ED: Using the Scratch (en anglais)
 
     </script>


### PR DESCRIPTION
Note that the French page always linked to the English version of the guide - there does not appear to be a French version of the TLC guide.